### PR TITLE
dynamic prompts を利用したときにもタグが正しく保存されるオプションを追加しました

### DIFF
--- a/scripts/eagle-pnginfo.py
+++ b/scripts/eagle-pnginfo.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import gradio as gr
 
@@ -22,6 +23,7 @@ def on_ui_settings():
     shared.opts.add_option("enable_eagle_integration", shared.OptionInfo(False, "Send all image to Eagle", section=("eagle_pnginfo", "Eagle Pnginfo")))
     # flg: save generation info to annotation
     shared.opts.add_option("save_generationinfo_to_eagle_as_annotation", shared.OptionInfo(False, "Save Generation info as Annotation", section=("eagle_pnginfo", "Eagle Pnginfo")))
+    shared.opts.add_option("save_pnginfo_prompt_to_eagle_as_tags", shared.OptionInfo(False, "Save pnginfo prompt to Eagle as tags. If you use the DynamicPrompts extension, enable it. When enabled, other prompt options are ignored.", section=("eagle_pnginfo", "Eagle Pnginfo")))
     # flg: save positive prompt to tags
     shared.opts.add_option("save_positive_prompt_to_eagle_as_tags", shared.OptionInfo(False, "Save positive prompt to Eagle as tags", section=("eagle_pnginfo", "Eagle Pnginfo")))
     shared.opts.add_option("save_negative_prompt_to_eagle_as", shared.OptionInfo("n:tag", "Save negative prompt as", gr.Radio, {"choices": ["None", "tag", "n:tag"]}, section=("eagle_pnginfo", "Eagle Pnginfo")))
@@ -53,20 +55,36 @@ def on_image_saved(params:script_callbacks.ImageSaveParams):
         tags = []
         if shared.opts.save_generationinfo_to_eagle_as_annotation:
             annotation = info
-        if shared.opts.save_positive_prompt_to_eagle_as_tags:
-            if len(pos_prompt.split(",")) > 0:
-                tags += Parser.prompt_to_tags(pos_prompt)
-        if shared.opts.save_negative_prompt_to_eagle_as == "tag":
-            if len(neg_prompt.split(",")) > 0:
-                tags += Parser.prompt_to_tags(neg_prompt)
-        elif shared.opts.save_negative_prompt_to_eagle_as == "n:tag":
-            if len(neg_prompt.split(",")) > 0:
-                tags += [ f"n:{x}" for x in Parser.prompt_to_tags(neg_prompt) ]
-        if shared.opts.additional_tags_to_eagle != "":
-            gen = TagGenerator(p=params.p, image=params.image)
-            _tags = gen.generate_from_p(shared.opts.additional_tags_to_eagle)
-            if _tags and len(_tags) > 0:
-                tags += _tags
+        if shared.opts.save_pnginfo_prompt_to_eagle_as_tags:
+            prompt_info = re.sub(r'(?<!\\)\(', '', info)
+            prompt_info = re.sub(r':[.0-9]+\)', '', prompt_info)
+            prompt_info = re.sub(r'(?<!\\)\)', '', prompt_info)
+            prompt_info = re.sub(r'\\', '', prompt_info)
+            prompt_lines = prompt_info.splitlines()
+            for word in prompt_lines[0].split(','):
+                w = word.strip()
+                if w != "":
+                    tags.append(w)
+            if re.match(r'^Negative prompt:', prompt_lines[1]):
+                for word in prompt_lines[1].split(','):
+                    w = word.strip()
+                    if w != "":
+                        tags.append("n:" + w)
+        else:
+            if shared.opts.save_positive_prompt_to_eagle_as_tags:
+                if len(pos_prompt.split(",")) > 0:
+                    tags += Parser.prompt_to_tags(pos_prompt)
+            if shared.opts.save_negative_prompt_to_eagle_as == "tag":
+                if len(neg_prompt.split(",")) > 0:
+                    tags += Parser.prompt_to_tags(neg_prompt)
+            elif shared.opts.save_negative_prompt_to_eagle_as == "n:tag":
+                if len(neg_prompt.split(",")) > 0:
+                    tags += [ f"n:{x}" for x in Parser.prompt_to_tags(neg_prompt) ]
+            if shared.opts.additional_tags_to_eagle != "":
+                gen = TagGenerator(p=params.p, image=params.image)
+                _tags = gen.generate_from_p(shared.opts.additional_tags_to_eagle)
+                if _tags and len(_tags) > 0:
+                    tags += _tags
 
         def _get_folderId(folder_name_or_id, allow_create_new_folder, server_url="http://localhost", port=41595):
             _ret = api_util.find_or_create_folder(folder_name_or_id, allow_create_new_folder, server_url, port)

--- a/scripts/eagle-pnginfo.py
+++ b/scripts/eagle-pnginfo.py
@@ -46,8 +46,11 @@ def on_image_saved(params:script_callbacks.ImageSaveParams):
         info = params.pnginfo.get('parameters', None)
         filename = os.path.splitext(os.path.basename(fullfn))[0]
         #
-        pos_prompt = params.p.prompt
-        neg_prompt = params.p.negative_prompt
+        pos_prompt = ""
+        neg_prompt = ""
+        if params.p is not None:
+            pos_prompt = params.p.prompt
+            neg_prompt = params.p.negative_prompt
         #
         annotation = None
         tags = []

--- a/scripts/tag_generator.py
+++ b/scripts/tag_generator.py
@@ -5,12 +5,12 @@ class TagGenerator():
     # @seealso modules.images FilenameGenerator replacements
     # @seealso modules.processing create_infotext generation_params
     replacements ={
-        "Steps": lambda self: self.p.steps,
-        "Sampler": lambda self: self.p.sampler_name,
-        "CFG scale": lambda self: self.p.cfg_scale,
+        "Steps": lambda self: '' if self.p is None else self.p.steps,
+        "Sampler": lambda self: '' if self.p is None else self.p.sampler_name,
+        "CFG scale": lambda self: '' if self.p is None else self.p.cfg_scale,
         "Seed": lambda self: self.p.seed if self.p.seed is not None else '',
         "Face restoration": lambda self: (shared.opts.face_restoration_model if self.p.restore_faces else None),
-        "Size": lambda self: f"{self.p.width}x{self.p.height}",
+        "Size": lambda self: '' if self.p is None else f"{self.p.width}x{self.p.height}",
         "Model hash": lambda self: getattr(self.p, 'sd_model_hash', None if not shared.opts.add_model_hash_to_info or not shared.sd_model.sd_model_hash else shared.sd_model.sd_model_hash),
         "Model": lambda self: (None if not shared.opts.add_model_name_to_info or not shared.sd_model.sd_checkpoint_info.model_name else shared.sd_model.sd_checkpoint_info.model_name.replace(',', '').replace(':', '')),
         "Hypernet": lambda self: (None if shared.loaded_hypernetwork is None else shared.loaded_hypernetwork.name),


### PR DESCRIPTION
Dynamic Prompts エクステンションを使った場合、「{pink|blue} hair」のように指定すると
「pink hair」「blue hair」のいずれかをランダムに選んでくれるのですが、
eagleのタグには Dynamic Prompts 処理前の状態で処理されてしまうようでした。

そこで、Save pnginfo prompt to Eagle as tags.  オプションを有効にすると、
params.pnginfo.get('parameters', None)
の情報からタグを取り出すようにしてみました。
とりあえずなので強調は除外、ネガティブプロンプトは常に追加で直してみたのですがいかがでしょうか。
ドキュメント等はまだ直してないのですが、良さそうであればそちらもなおします。

よろしくお願いします。


