### PR TITLE
stable-diffusion-webui-docker対応のため、localhost判定処理にhost.docker.internalを追加

### DIFF
--- a/scripts/eagleapi/api_util.py
+++ b/scripts/eagleapi/api_util.py
@@ -9,7 +9,7 @@ def get_url_port(server_url_port=""):
         return None, None
     o = urlparse(server_url_port)
     _url = f"http://{o.hostname}"
-    if o.hostname != "localhost":
+    if o.hostname != "localhost" and o.hostname != "host.docker.internal":
         _ip = ipaddress.ip_address(o.hostname)
         if _ip.version == 6:
             _url = f"http://[{o.hostname}]"


### PR DESCRIPTION
[stable-diffusion-webui-docker](https://github.com/AbdBarho/stable-diffusion-webui-docker)に対応するため、Docker Desktopからホストを参照する際に利用される「host.docker.internal」をlocalhost判定処理に追加しました。